### PR TITLE
Fix interval cleanup when goal reached

### DIFF
--- a/src/Components/GroupTableControl/GroupTableControl.tsx
+++ b/src/Components/GroupTableControl/GroupTableControl.tsx
@@ -47,11 +47,12 @@ export const GroupTableControl = () => {
             const newData: Array<VKGroup> = [];
             for (let group of data) {
                 const membersCount = await fetchData(group.key);
-                if (membersCount.value >= group.membersGoal) {
-                    clearInterval(intervalId);
-                    setShowPopup(true);
-                    reachedGroup = group;
-                } else {
+                    if (membersCount.value >= group.membersGoal) {
+                        clearInterval(intervalId);
+                        setIntervalId(null);
+                        setShowPopup(true);
+                        reachedGroup = group;
+                    } else {
                     newData.push({ ...group, value: membersCount.value });
                 }
             }


### PR DESCRIPTION
## Summary
- reset interval state when a group's goal is reached

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_683f43acb90c8320b5ae89bb6b2df171