### PR TITLE
Fix createContext generic

### DIFF
--- a/src/Components/Context.ts
+++ b/src/Components/Context.ts
@@ -19,10 +19,9 @@ export const dataContext = createContext<dataContextType>({
     setData: () => {}
 });
 
-export const loopContext = createContext(<loopContextType>({
-        intervalId: null,
-        setIntervalId: () => {},
-        appState: ApplicationState.Disabled,
-        setAppState: () => {}
-    })
-);
+export const loopContext = createContext<loopContextType>({
+    intervalId: null,
+    setIntervalId: () => {},
+    appState: ApplicationState.Disabled,
+    setAppState: () => {},
+});


### PR DESCRIPTION
## Summary
- use a generic parameter for `loopContext` instead of a cast

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f450337d08320ae52a84c773af95f