### PR TITLE
Improve UX and fix duplicate group bug

### DIFF
--- a/src/Components/GroupDisplay/GroupDisplay.tsx
+++ b/src/Components/GroupDisplay/GroupDisplay.tsx
@@ -1,7 +1,6 @@
 import { VKGroup } from "../../../types";
 import React from "react";
 import styles from './GroupDisplay.module.scss';
-import {VK} from "vk-io";
 
 interface GroupDisplayProps {
     group: VKGroup;
@@ -11,7 +10,8 @@ const GroupDisplay: React.FC<GroupDisplayProps> = ({ group }) => {
 
     function isGroupValid(group: VKGroup) {
         for (const key in group) {
-            if (!group[key]) {
+            const value = group[key];
+            if (value === undefined || value === '') {
                 return false;
             }
         }

--- a/src/Components/GroupInput/GroupInput.tsx
+++ b/src/Components/GroupInput/GroupInput.tsx
@@ -31,12 +31,14 @@ const GroupInput: React.FC<GroupInputProps> = ({ onSubmit }) => {
                         onChange={(value: string) => {
                             setInputGroupNameValue(value);
                         }}
+                        placeholder="my_group"
                     />
                     <TextInput
                         label="Enter Members Count goal: "
                         type="number"
                         value={inputMembersCountGoal}
                         onChange={(value: number) => setInputMembersCountGoal(value)}
+                        placeholder="1000"
                     />
                 <button className="group-form__submit" type="submit">Submit</button>
             </form>

--- a/src/Components/GroupInputControl/GroupInputControl.tsx
+++ b/src/Components/GroupInputControl/GroupInputControl.tsx
@@ -1,11 +1,10 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import { VKGroup } from "../../../types";
 import { dataContext, loopContext } from "@/Components/Context";
 import { ApplicationState } from "@/Components/LoopButton";
 import { fetchData } from "@/lib/api";
 import TextInput from "../TextInput/TextInput";
 import GroupInput from "@/Components/GroupInput/GroupInput";
-import {VK} from "vk-io";
 import GroupDisplay from "@/Components/GroupDisplay/GroupDisplay";
 import GroupAddButton from "@/Components/GroupAddButton/GroupAddButton";
 import styles from "./GroupInputControl.module.scss"
@@ -16,7 +15,7 @@ export function isButtonDisabled(Group: VKGroup, data: Array<VKGroup>): boolean 
     const valueEmpty = !Group.value;
     const valueError = Group.value === "Error";
     const groupAlreadyThere = data.some(
-        (group) => group.key === Group.key && group.value === Group.value
+        (group) => group.key === Group.key
     );
     return keyEmpty || valueEmpty || valueError || groupAlreadyThere;
 }
@@ -27,6 +26,7 @@ const GroupInputControl = () => {
 
     const [currentGroup, setCurrentGroup] = useState<VKGroup>(initialGroup);
     const [isAddButtonDisabled, setIsAddButtonDisabled] = useState(true);
+    const [formKey, setFormKey] = useState(0);
 
     const { intervalId, setAppState } = useContext(loopContext);
     const { data } = useContext(dataContext);
@@ -42,6 +42,7 @@ const GroupInputControl = () => {
             setCurrentGroup(newGroup);
             setIsAddButtonDisabled(isButtonDisabled(newGroup, data));
         } catch {
+            setCurrentGroup(initialGroup);
             setIsAddButtonDisabled(true);
         }
     };
@@ -53,6 +54,7 @@ const GroupInputControl = () => {
     const handleAddClick = () => {
         setCurrentGroup(initialGroup);
         setIsAddButtonDisabled(true);
+        setFormKey((k) => k + 1);
     };
 
 
@@ -61,7 +63,7 @@ const GroupInputControl = () => {
     return (
         <div className={styles['group-input-control']}>
             <div>
-                <GroupInput onSubmit={handleInputSubmit} />
+                <GroupInput key={formKey} onSubmit={handleInputSubmit} />
             </div>
             <div className={styles.test}>
                 <GroupDisplay group={currentGroup}/>

--- a/src/Components/GroupInputControl/__tests__/isButtonDisabled.test.ts
+++ b/src/Components/GroupInputControl/__tests__/isButtonDisabled.test.ts
@@ -16,6 +16,11 @@ describe('isButtonDisabled', () => {
     expect(isButtonDisabled(group, data)).toBe(true)
   })
 
+  it('duplicate key with different value ⇒ true', () => {
+    const group: VKGroup = { key: 'group1', value: 999, membersGoal: 0 }
+    expect(isButtonDisabled(group, data)).toBe(true)
+  })
+
   it('valid unique group ⇒ false', () => {
     const group: VKGroup = { key: 'group2', value: 456, membersGoal: 0 }
     expect(isButtonDisabled(group, data)).toBe(false)

--- a/src/Components/GroupTableControl/GroupTableControl.tsx
+++ b/src/Components/GroupTableControl/GroupTableControl.tsx
@@ -38,7 +38,6 @@ export const GroupTableControl = () => {
             setAppState(ApplicationState.Enabled);
         else
             setAppState(ApplicationState.Disabled);
-        console.log(intervalId)
     }, [data, intervalId, setAppState, setIntervalId])
     const handleStartLoop = () => {
 
@@ -95,18 +94,24 @@ export const GroupTableControl = () => {
                     </tr>
                     </thead>
                     <tbody>
-                    {data.map((item) => (
-                        <tr key={item.key}>
-                            <td>{item.key}</td>
-                            <td>{item.value}</td>
-                            <td>{item.membersGoal}</td>
-                            <td>
-                                <button disabled={Boolean(intervalId)} onClick={() => {
-                                    deleteGroup(item.key)
-                                }}>Delete</button>
-                            </td>
+                    {data.length === 0 ? (
+                        <tr>
+                            <td colSpan={4}>No groups added</td>
                         </tr>
-                    ))}
+                    ) : (
+                        data.map((item) => (
+                            <tr key={item.key}>
+                                <td>{item.key}</td>
+                                <td>{item.value}</td>
+                                <td>{item.membersGoal}</td>
+                                <td>
+                                    <button disabled={Boolean(intervalId)} onClick={() => {
+                                        deleteGroup(item.key)
+                                    }}>Delete</button>
+                                </td>
+                            </tr>
+                        ))
+                    )}
                     </tbody>
                 </table>
 

--- a/src/Components/TextInput/TextInput.tsx
+++ b/src/Components/TextInput/TextInput.tsx
@@ -6,6 +6,7 @@ type TextProps = {
     value: string;
     type: "text";
     onChange: (value: string) => void;
+    placeholder?: string;
 };
 
 type NumberProps = {
@@ -13,11 +14,12 @@ type NumberProps = {
     value: number;
     type: "number";
     onChange: (value: number) => void;
+    placeholder?: string;
 };
 
 type Props = TextProps | NumberProps;
 
-export default function TextInput({ label, value, type, onChange }: Props) {
+export default function TextInput({ label, value, type, onChange, placeholder }: Props) {
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         event.preventDefault();
         if (type === "number") {
@@ -36,7 +38,12 @@ export default function TextInput({ label, value, type, onChange }: Props) {
     return (
         <div className={styles["text-input"]}>
             <label>{label}</label>
-            <input type={type} value={value === 0 ? "" : value} onChange={handleChange} />
+            <input
+                type={type}
+                value={value === 0 ? "" : value}
+                onChange={handleChange}
+                placeholder={placeholder}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- prevent false negative group validation
- allow placeholders in `TextInput`
- add placeholders in group input form
- avoid duplicates when group value changes
- reset group form after adding a group
- show empty message in group table
- clean up unused imports and logs
- test duplicate check with changed value

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843927918c4832089f218944e350eb1